### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
               make init
               make github/init/context.tf
               make readme/build
-              echo "::set-output name=create_pull_request::true"
+              echo "create_pull_request=true" >> $GITHUB_OUTPUT
             fi
           else
             echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/